### PR TITLE
Remove the default parameter

### DIFF
--- a/IndexIVFPQ.h
+++ b/IndexIVFPQ.h
@@ -60,7 +60,7 @@ struct IndexIVFPQ: IndexIVF {
             Index * quantizer, size_t d, size_t nlist,
             size_t M, size_t nbits_per_idx, MetricType metric = METRIC_L2);
 
-    void add_with_ids(idx_t n, const float* x, const idx_t* xids = nullptr)
+    void add_with_ids(idx_t n, const float* x, const idx_t* xids)
         override;
 
     void encode_vectors(idx_t n, const float* x,


### PR DESCRIPTION
`IndexIVFPQR::add_with_ids` has a default parameter `xids` which causes swig generates different function signatures for go, to be more specific, for functions with default params, swig would translate it to an `interface{}`:
```
void add_with_ids(idx_t n, const float* x, const idx_t* xids = nullptr) override
```
got translated to
```
func (arg1 SwigcptrIndexIVFPQ) Add_with_ids(a interface{})
```
which is supposed to be:
```
func (arg1 SwigcptrIndexIVFPQ) Add_with_ids(arg2 int64, arg3 *float32, arg4 *int64)
```

This makes `faiss.Write_index` complain about the index conversion, e.g.:
```
indexer := faiss.NewIndexIVFPQ(quantizer, int64(d), nCentroids, int64(64), int64(8))
faiss.Write_index(faiss.Index(indexer), string("./index.idx")))
```
would throw error message:
```
faiss.IndexIVFPQ does not implement faiss.Index (wrong type for Add_with_ids method)
		have Add_with_ids(...interface {})
		want Add_with_ids(int64, *float32, *int64)
```

Env:
 - SWIG: 4.0.1, [default arguments](http://www.swig.org/Doc4.0/SWIGDocumentation.html#SWIGPlus_default_args)
 - GO: go1.13.8 darwin/amd64
 - faiss: c6bc8c46f1decc109573978ad2b6d616b07b8eac